### PR TITLE
Read unicode characters from README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ import os
 from setuptools import setup
 
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'README.rst')) as fd:
+with open(os.path.join(here, 'README.rst'), encoding='utf-8') as fd:
     long_description = fd.read()
 
 


### PR DESCRIPTION
Reading without specifying the encoding works on my dev environment. However when installing on Ubuntu 16.04 with Python 3.6.8, I had the following error:

```
Complete output from command python setup.py egg_info:
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/imagecluster/setup.py", line 13, in <module>
    long_description = fd.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2619: ordinal not in range(128)
```
The non-ascii characters in question are the ones describing the directory structure.