### PR TITLE
fix high similarity index error

### DIFF
--- a/imagecluster/postproc.py
+++ b/imagecluster/postproc.py
@@ -25,15 +25,14 @@ def plot_clusters(clusters, images, max_csize=None, mem_limit=1024**3):
         have (i) enough memory, (ii) many clusters and/or (iii) large
         max(csize) and (iv) max_csize is large or None
     """
+    if len(clusters) < 1:
+        print('Similarity is too high, each image is its own cluster, no need to visualize it.')
+        return
     stats = ic.cluster_stats(clusters)
     if max_csize is not None:
         stats = stats[stats[:,0] <= max_csize, :]
     # number of clusters
-    try:
-        ncols = stats[:, 1].sum()
-    except IndexError:
-        print('Similarity is too high, each image is its own cluster, no need to visualize it.')
-        return
+    ncols = stats[:, 1].sum()
     # csize (number of images per cluster)
     nrows = stats[:,0].max()
     shape = images[list(images.keys())[0]].shape[:2]

--- a/imagecluster/postproc.py
+++ b/imagecluster/postproc.py
@@ -32,7 +32,7 @@ def plot_clusters(clusters, images, max_csize=None, mem_limit=1024**3):
     if max_csize is not None:
         stats = stats[stats[:,0] <= max_csize, :]
     # number of clusters
-    ncols = stats[:, 1].sum()
+    ncols = stats[:,1].sum()
     # csize (number of images per cluster)
     nrows = stats[:,0].max()
     shape = images[list(images.keys())[0]].shape[:2]

--- a/imagecluster/postproc.py
+++ b/imagecluster/postproc.py
@@ -29,7 +29,11 @@ def plot_clusters(clusters, images, max_csize=None, mem_limit=1024**3):
     if max_csize is not None:
         stats = stats[stats[:,0] <= max_csize, :]
     # number of clusters
-    ncols = stats[:,1].sum()
+    try:
+        ncols = stats[:, 1].sum()
+    except IndexError:
+        print('Similarity is too high, each image is its own cluster, no need to visualize it.')
+        return
     # csize (number of images per cluster)
     nrows = stats[:,0].max()
     shape = images[list(images.keys())[0]].shape[:2]

--- a/imagecluster/postproc.py
+++ b/imagecluster/postproc.py
@@ -26,7 +26,7 @@ def plot_clusters(clusters, images, max_csize=None, mem_limit=1024**3):
         max(csize) and (iv) max_csize is large or None
     """
     if len(clusters) < 1:
-        print('Similarity is too high, each image is its own cluster, no need to visualize it.')
+        print('No cluster meets the requirements of sim and min_csize, can\'t visualize it.')
         return
     stats = ic.cluster_stats(clusters)
     if max_csize is not None:

--- a/imagecluster/postproc.py
+++ b/imagecluster/postproc.py
@@ -25,9 +25,7 @@ def plot_clusters(clusters, images, max_csize=None, mem_limit=1024**3):
         have (i) enough memory, (ii) many clusters and/or (iii) large
         max(csize) and (iv) max_csize is large or None
     """
-    if len(clusters) < 1:
-        print('No cluster meets the requirements of sim and min_csize, can\'t visualize it.')
-        return
+    assert len(clusters) > 0, "`clusters` is empty"
     stats = ic.cluster_stats(clusters)
     if max_csize is not None:
         stats = stats[stats[:,0] <= max_csize, :]


### PR DESCRIPTION
High similarity (for example: sim=0.99) might raise IndexError:

```
Traceback (most recent call last):
  File "/mnt/c/Users/sunji/PycharmProjects/imagecluster/main.py", line 24, in <module>
    postproc.visualize(clusters, images)
  File "/mnt/c/Users/sunji/PycharmProjects/imagecluster/imagecluster/postproc.py", line 63, in visualize
    plot_clusters(*args, **kwds)
  File "/mnt/c/Users/sunji/PycharmProjects/imagecluster/imagecluster/postproc.py", line 32, in plot_clusters
    ncols = stats[:,1].sum()
IndexError: too many indices for array
```
